### PR TITLE
Clarified AddEffect() and fixed a FollowUp/Summon attack bug

### DIFF
--- a/FrogBattleV2/Classes/Characters/Bayonetta.cs
+++ b/FrogBattleV2/Classes/Characters/Bayonetta.cs
@@ -87,7 +87,7 @@ namespace FrogBattleV2.Classes.Characters
             Abilities = Weapons[0];
         }
         #region Weapon 1 Abilities
-        private static uint ability1boost = 0;
+        private uint ability1boost = 0;
         private string Ability11(Fighter target)
         {
             string output = $"{Name} punches and kicks {target.Name}!\n";

--- a/FrogBattleV2/Classes/Characters/MamiTomoe.cs
+++ b/FrogBattleV2/Classes/Characters/MamiTomoe.cs
@@ -288,7 +288,7 @@ namespace FrogBattleV2.Classes.Characters
                 totalDmg += dmg;
                 output += $"\n{target.Name} takes {dmg:0.#} damage!" + target.TakeDamage(dmg, this);
             }
-            target.AddEffect(LingeringElegance, (PrecisionStacks + 1) / 7);
+            if (PrecisionStacks >= 6) target.AddEffect(LingeringElegance, (PrecisionStacks + 1) / 7);
             return output + $"\n{Name} has dealt a total of {totalDmg:0.#} damage to {target.Name}!";
         }
         #endregion
@@ -299,7 +299,7 @@ namespace FrogBattleV2.Classes.Characters
             GetEnergy(5);
             if (RNG < 0.01)
             {
-                dmg = MediumDmg(Atk * 10, 0, target);
+                dmg = MediumDmg(Atk * 10, DmgType.None, target);
                 return $"\nCharlotte REALLY NEEDS that cheese and goes a bit overboard, chomping off {target.Name}'s" +
                     $" head and dealing {dmg:0.#} damage!{target.TakeDamage(dmg, null)}";
             }

--- a/FrogBattleV2/Classes/GameLogic/Fighter.cs
+++ b/FrogBattleV2/Classes/GameLogic/Fighter.cs
@@ -452,7 +452,8 @@ namespace FrogBattleV2.Classes.GameLogic
             if (turns > StunTime) StunTime = turns;
         }
         /// <summary>
-        /// Checks ActiveEffects for an identical effect, then adds stacks to it (if stackable) and refreshes its duration.
+        /// <para>Checks ActiveEffects for an identical effect, then adds stacks to it (if stackable) and refreshes its duration.</para>
+        /// <para>Throws an exception if <paramref name="totalStacks"/> is less than 1.</para>
         /// </summary>
         /// <param name="effect">The effect to be stacked, refreshed or added at the end of ActiveEffects.</param>
         public void AddEffect(StatusEffect effect, uint totalStacks = 1)
@@ -591,7 +592,8 @@ namespace FrogBattleV2.Classes.GameLogic
             else abilityResult = Abilities[nr-1].ExecuteAbility(this, target);
             //if (this is IFollowsUp followsUp && abilityResult.IsUsable) return abilityResult with { Message = abilityResult.Message + followsUp.FollowUp.ExecuteAbility(this, target).Message };
             //if (this is IAbilityBonus bonus && ???) return abilityResult with { Message = abilityResult.Message + bonus.Bonus.ExecuteAbility(this, target).Message };
-            return abilityResult + (nr != 0 && this is IFollowsUp followsUp ? followsUp.FollowUp.ExecuteAbility(this, target) : AbilityCheckResult.Empty) + (this is ISummons summons ? summons.Summon.ExecuteAbility(this, target) : AbilityCheckResult.Empty);
+            if (abilityResult.CanContinue) return abilityResult + (nr != 0 && this is IFollowsUp followsUp ? followsUp.FollowUp.ExecuteAbility(this, target) : AbilityCheckResult.Empty) + (this is ISummons summons ? summons.Summon.ExecuteAbility(this, target) : AbilityCheckResult.Empty);
+            else return abilityResult;
         }
         internal AbilityCheckResult CheckUsability(Ability ability)
         {


### PR DESCRIPTION
- Made it clear that AddEffect(effect, totalStacks) throws an exception if totalStacks is 0;
- Minor change in MamiTomoe.cs to accomodate this realisation;
- Fixed FollowUp/Summon attacks from executing alongside turn repeating actions (such as when trying to use an attack with too little mana);
- Minor change in Bayonetta.cs due to an incorrect previous assumption that a field could be marked as static.